### PR TITLE
Update API version to v8

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const request = require("request");
 const config = require("./config.json");
-const STATUS_URL = "https://discordapp.com/api/v6/users/@me/settings";
+const STATUS_URL = "https://discordapp.com/api/v8/users/@me/settings";
 
 async function loop() {
 	for (let anim of config.animation) {


### PR DESCRIPTION
Update API version to v8 because v6 are ``Deprecated``
[Reference](https://discord.com/developers/docs/reference#api-versioning-api-versions)